### PR TITLE
Fix for Invisible Previews of SVGs

### DIFF
--- a/src/SvgUploadPreview.css
+++ b/src/SvgUploadPreview.css
@@ -35,6 +35,8 @@
 .svgWrapper svg {
 	max-height: 200px;
 	max-width: 300px;
+	width: 100%;
+	height: 100%;
 }
 
 .svgPreviewBackground.hasValue:after {


### PR DESCRIPTION
I'm not certain that this is the best solution for this, but when using SVGs that have no default height or width set they have a height and width of `0px` in the preview. With this modification they will always take up the full container still honoring the max pixel dimensions defined previously.