### PR TITLE
Generate field ids

### DIFF
--- a/src/SvgUploadPreview.js
+++ b/src/SvgUploadPreview.js
@@ -40,15 +40,21 @@ class SvgStringInput extends React.Component {
     return false
   }
 
+  generateId() {
+    const title = this.props.type.title.replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => index == 0 ? word.toLowerCase() : word.toUpperCase()).replace(/\s+/g, '')
+    return `svg-upload--${title}`
+  }
+
   render() {
     const { value, type, level } = this.props;
+    const id = this.generateId();
 
     return (
       <FormField label={type.title} level={level} description={type.description}>
         <div className={`${styles.svgPreviewBackground} ${value && styles.hasValue}`}>
           <input
             accept=".svg"
-            id="svg-upload"
+            id={id}
             ref={this.inputRef}
             type="file"
             placeholder={type.placeholder}
@@ -56,7 +62,7 @@ class SvgStringInput extends React.Component {
             name="svg_upload"
             onSubmit={this.onSubmit}
           />
-          <label htmlFor="svg-upload">Upload SVG</label>
+          <label htmlFor={id}>Upload SVG</label>
 
           {value && (
             <div className={styles.svgWrapper}>

--- a/src/SvgUploadPreview.js
+++ b/src/SvgUploadPreview.js
@@ -42,7 +42,7 @@ class SvgStringInput extends React.Component {
 
   generateId() {
     const title = this.props.type.title.replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => index == 0 ? word.toLowerCase() : word.toUpperCase()).replace(/\s+/g, '')
-    return `svg-upload--${title}`
+    return `svg-upload--${this.props.parent._key}--${title}`
   }
 
   render() {


### PR DESCRIPTION
This fixes #12 by generating an id for each svg upload field, based on the field title and parent key. So long as the field title is unique within the parent item, so will the field id be. Can possibly be made more robust, but this is a solid improvement on where we are now. 